### PR TITLE
Allow parameterizing bundler version

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -14,7 +14,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.6"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.17.3"
+  BUNDLER_VERSION      = env("CUSTOM_BUNDLER_VERSION") || "1.17.3"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
   NODE_BP_PATH         = "vendor/node/bin"


### PR DESCRIPTION
The plan is:

1. merge this buildpack update. It has no effect because the environment
   variable is not set
2. update crystal's environment in QA to use the new bundler version, confirm it successfully uses it
3. update crystal's environment in production in the same manner

Optionally, we can come back to this and update it so that it uses 2.0.2
by default.